### PR TITLE
Updated play.rb 3.29.2016

### DIFF
--- a/lib/play.rb
+++ b/lib/play.rb
@@ -24,10 +24,10 @@ def turn(board)
   input = gets.strip
   if valid_move?(board, input)
     move(board, input)
+    display_board(board)
   else
     turn(board)
   end
-  display_board(board)
 end
 
 # Define your play method below


### PR DESCRIPTION
Line numbers reference original. 

#display_board(board) [line 30] has been relocated to [line 27] 

This prevents the board from reprinting twice after an invalid input was received. 
The original program bin/play in terminal:

`[22:02:56] (master) ttt-9-play-loop-q-000
// ♥ ruby bin/play
Welcome to Tic Tac Toe!
   |   |   
-----------
   |   |   
-----------
   |   |   
Please enter 1-9:
44
Please enter 1-9:
4
   |   |   
-----------
 X |   |   
-----------
   |   |   
   |   |   
-----------
 X |   |   
-----------
   |   |   
Please enter 1-9:`

The proposed update:

`[22:04:05] (master) ttt-9-play-loop-q-000
// ♥ ruby bin/play
Welcome to Tic Tac Toe!
   |   |   
-----------
   |   |   
-----------
   |   |   
Please enter 1-9:
44
Please enter 1-9:
4
   |   |   
-----------
 X |   |   
-----------
   |   |   
Please enter 1-9:`